### PR TITLE
In CentOs 7 (and RedHat most possible) server called nfs-server

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,2 +1,2 @@
 ---
-nfs_server_daemon: nfs
+nfs_server_daemon: nfs-server


### PR DESCRIPTION
Fix of https://github.com/geerlingguy/ansible-role-nfs/issues/9

What interesting, nfs alias allowed as shorthand to check status for example:

nfs-server.service - NFS server and services
   Loaded: loaded (/usr/lib/systemd/system/nfs-server.service; enabled)
   Active: active (exited) since Ср 2015-08-05 21:17:18 MSK; 2 months 2 days ago
   ...

but on try to enable it fails:
Failed to issue method call: No such file or directory