### PR TITLE
Add support for Fedora systems

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,10 @@
   include_vars: RedHat-7.yml
   when: ansible_os_family == 'RedHat' and ansible_distribution_major_version == "7"
 
+- name: Include overrides specific to Fedora.
+  include_vars: Fedora.yml
+  when: ansible_os_family == 'RedHat' and ansible_distribution == "Fedora"
+
 # Setup/install tasks.
 - include: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure NFS utilities are installed.
-  yum: name=nfs-utils state=installed
+  package: name=nfs-utils state=installed
 
 - name: Ensure rpcbind is running.
   service: name=rpcbind state=started enabled=yes

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -1,0 +1,2 @@
+---
+nfs_server_daemon: nfs-server


### PR DESCRIPTION
I was playing around trying to reuse this excellent role on a Fedora cloud image I use for my development and staging cloud instances.

There were only a few things missing - we need to make sure we use the right package manager (since Fedora has moved to dnf instead of yum since 22) and also what appears to be a package needed for dealing with SELinux.

I've tested this on a basically vanilla Fedora 23 cloud image (https://download.fedoraproject.org/pub/fedora/linux/releases/23/Cloud/x86_64/Images/Fedora-Cloud-Base-23-20151030.x86_64.qcow2). Fedora 23 does not come with python 2 so that's an obvious pre-req for running Ansible at all, but other than that it worked out of the box.

Let me know if this seems useful, and if I can improve it in any way!