### PR TITLE
Use exportfs -ra instead of restarting the NFS service

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,3 @@
 ---
-- name: restart nfs
-  service: "name={{ nfs_server_daemon }} state=restarted"
-  when: nfs_exports|length
+- name: reload nfs
+  command: 'exportfs -ra'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,6 @@
 - name: Ensure directories to export exist
   file: 'path="{{ item.strip().split()[0] }}" state=directory'
   with_items: "{{ nfs_exports }}"
-  notify: restart nfs
 
 - name: Copy exports file.
   template:
@@ -30,12 +29,7 @@
     owner: root
     group: root
     mode: 0644
-  register: nfs_exports_copy
-  notify: restart nfs
-
-- name: Restart NFS immediately if exports are updated.
-  service: "name={{ nfs_server_daemon }} state=restarted"
-  when: nfs_exports_copy.changed
+  notify: reload nfs
 
 - name: Ensure nfs is running.
   service: "name={{ nfs_server_daemon }} state=started enabled=yes"


### PR DESCRIPTION
This will avoid breaking already existing mounts and is quicker to do.

I removed the notify on "Ensure directories to export exist" because I don't think this is the condition to reload the NFS server config, it will be done if the `nfs_exports` changed anyways...

I tested that the `exportfs` command is available on centos:7 & debian:stretch when the NFS packages are installed.

This has been lightly tested here, please advise how to proceed for merging...