### PR TITLE
Pass the list of packages to apt directly

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,6 +1,7 @@
 ---
 - name: Ensure NFS utilities are installed.
-  apt: "name={{ item }} state=present"
-  with_items:
-    - nfs-common
-    - nfs-kernel-server
+  apt:
+    name:
+      - nfs-common
+      - nfs-kernel-server
+    state: present


### PR DESCRIPTION
The current method results in a deprecation warning on the current development version of Ansible. The warning looks like:

```
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying 
`name: {{ item }}`, please use `name: ['nfs-common', 'nfs-kernel-server']` and remove the loop. This feature will be removed in version 2.11. Deprecation warnings can be
 disabled by setting deprecation_warnings=False in ansible.cfg.
```

Passing a list of packages directly as the `name:` to apt is also supposedly faster (although I should think the difference is probably negligible with just 2 packages to be installed).

The [Ansible changelog for 2.7](https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_2.7.html#using-a-loop-on-a-package-module-via-squash-actions) (where this was introduced) suggests that the new way should work on any version of Ansible since 2.3. I'm not sure which versions of Ansible this project targets so you may want to hold off merging for now if pre-2.3 versions need to stay supported.