### PR TITLE
Use include_tasks instead of include (fixes #20)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,10 +12,10 @@
   when: ansible_os_family == 'RedHat' and ansible_distribution == "Fedora"
 
 # Setup/install tasks.
-- include: setup-RedHat.yml
+- include_tasks: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'
 
-- include: setup-Debian.yml
+- include_tasks: setup-Debian.yml
   when: ansible_os_family == 'Debian'
 
 - name: Ensure directories to export exist


### PR DESCRIPTION
This should fix deprecation warnings as described in #20