### PR TITLE
Update NFS Ubuntu link to LTS url

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Available variables are listed below, along with default values (see `defaults/m
 
     nfs_exports: []
 
-A list of exports which will be placed in the `/etc/exports` file. See Ubuntu's simple [Network File System (NFS)](https://help.ubuntu.com/14.04/serverguide/network-file-system.html) guide for more info and examples. (Simple example: `nfs_exports: [ "/home/public    *(rw,sync,no_root_squash)" ]`).
+A list of exports which will be placed in the `/etc/exports` file. See Ubuntu's simple [Network File System (NFS)](https://help.ubuntu.com/lts/serverguide/network-file-system.html.en) guide for more info and examples. (Simple example: `nfs_exports: [ "/home/public    *(rw,sync,no_root_squash)" ]`).
 
     nfs_rpcbind_state: started
     nfs_rpcbind_enabled: true


### PR DESCRIPTION
the 14.04 URL is currently returning 404. Swapping out that link for a link to the LTS docs.