### PR TITLE
Included RedHat-7.yml for versions 7 and newer.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,11 +3,11 @@
 - name: Include OS-specific variables.
   include_vars: "{{ ansible_os_family }}.yml"
 
-- name: Include overrides specific to RHEL 7.
+- name: Include overrides specific to RHEL 7 and newer.
   include_vars: RedHat-7.yml
   when:
     - ansible_os_family == 'RedHat'
-    - ansible_distribution_major_version == "7"
+    - ansible_distribution_major_version|int >= 7
 
 - name: Include overrides specific to Fedora.
   include_vars: Fedora.yml


### PR DESCRIPTION
Currently, this role will fail on RHEL 8. This fix will allow it to work on both RHEL 7 & 8.