### PR TITLE
Update broken link to Ubuntu NFS guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Available variables are listed below, along with default values (see `defaults/m
 
     nfs_exports: []
 
-A list of exports which will be placed in the `/etc/exports` file. See Ubuntu's simple [Network File System (NFS)](https://help.ubuntu.com/lts/serverguide/network-file-system.html.en) guide for more info and examples. (Simple example: `nfs_exports: [ "/home/public    *(rw,sync,no_root_squash)" ]`).
+A list of exports which will be placed in the `/etc/exports` file. See Ubuntu's simple [Network File System (NFS)](https://ubuntu.com/server/docs/service-nfs) guide for more info and examples. (Simple example: `nfs_exports: [ "/home/public    *(rw,sync,no_root_squash)" ]`).
 
     nfs_rpcbind_state: started
     nfs_rpcbind_enabled: true


### PR DESCRIPTION
This is the short guide, but the bottom of the page includes references to the longer guide at https://help.ubuntu.com/community/SettingUpNFSHowTo