### PR TITLE
Remove import of deleted vars/RedHat-6.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,12 +3,6 @@
 - name: Include OS-specific variables.
   include_vars: "{{ ansible_os_family }}.yml"
 
-- name: Include overrides specific to RHEL 6 and below
-  include_vars: RedHat-6.yml
-  when:
-    - ansible_os_family == 'RedHat'
-    - ansible_distribution_major_version < "7"
-
 - name: Include overrides specific to Fedora.
   include_vars: Fedora.yml
   when:


### PR DESCRIPTION
Removing conditional import of now deleted `vars/RedHat-6.yml` since fd1c652fd82dba6b0d9defc73645a2f34a60538b
Popped up running role vs. Fedora 33 target which somehow matched condition.
@geerlingguy 