### PR TITLE
Fix folder duplicate checks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,9 +18,9 @@
 
 - name: Ensure directories to export exist
   file:  # noqa 208
-    path: "{{ item.strip().split()[0] }}"
+    path: "{{ item }}"
     state: directory
-  with_items: "{{ nfs_exports }}"
+  with_items: "{{ nfs_exports | map('split') | map('first') | unique }}"
 
 - name: Copy exports file.
   template:


### PR DESCRIPTION
A folder may be exported to multiple clients/ranges.
This patch ensures the folder existence is checked only once.

Besides, the strip function is useless, split does strip strings