### PR TITLE
setup-Debian: update apt cache when ensure that nfs-common is installed

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -5,3 +5,4 @@
       - nfs-common
       - nfs-kernel-server
     state: present
+    update_cache: yes


### PR DESCRIPTION
I was having some issues with an outdated pxe server using this role and we figure it was because apt was not updating. Let me know if you rather prefer to add another task before ensure nfs-commons with a variable defined in false by default.