### PR TITLE
fix: change conditional to explicit boolean

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,4 +33,4 @@
 
 - name: Ensure nfs is running.
   service: "name={{ nfs_server_daemon }} state=started enabled=yes"
-  when: nfs_exports|length
+  when: nfs_exports|length > 0


### PR DESCRIPTION
Fixing error message `[ERROR]: Task failed: Conditional result was '1' of type 'int', which evaluates to True. Conditionals must have a boolean result.`