### PR TITLE
add sle openSUSE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/geerlingguy/ansible-role-nfs/actions/workflows/ci.yml/badge.svg)](https://github.com/geerlingguy/ansible-role-nfs/actions/workflows/ci.yml)
 
-Installs NFS utilities on RedHat/CentOS or Debian/Ubuntu.
+Installs NFS utilities on RedHat/CentOS, Debian/Ubuntu, SLES/openSUSE.
 
 ## Requirements
 
@@ -19,7 +19,7 @@ A list of exports which will be placed in the `/etc/exports` file. See Ubuntu's 
     nfs_rpcbind_state: started
     nfs_rpcbind_enabled: true
 
-(RedHat/CentOS/Fedora only) The state of the `rpcbind` service, and whether it should be enabled at system boot.
+(RedHat/CentOS/Fedora/SLES only) The state of the `rpcbind` service, and whether it should be enabled at system boot.
 
 ## Dependencies
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,6 +18,12 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - all
+    - name: SLES
+      versions:
+        - all
+    - name: openSUSE
+      versions:
+        - all
   galaxy_tags:
     - system
     - nfs

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,9 @@
 - include_tasks: setup-Debian.yml
   when: ansible_facts.os_family == 'Debian'
 
+- include_tasks: setup-Suse.yml
+  when: ansible_facts.os_family == 'Suse'
+
 - name: Ensure directories to export exist
   file:  # noqa 208
     path: "{{ item }}"

--- a/tasks/setup-Suse.yml
+++ b/tasks/setup-Suse.yml
@@ -1,0 +1,13 @@
+---
+- name: Ensure NFS utilities are installed.
+  package:
+    name:
+      - nfs-kernel-server
+    state: present
+
+- name: Ensure rpcbind is running as configured.
+  service:
+    name: rpcbind
+    state: "{{ nfs_rpcbind_state }}"
+    enabled: "{{ nfs_rpcbind_enabled }}"
+

--- a/vars/Suse.yml
+++ b/vars/Suse.yml
@@ -1,0 +1,3 @@
+---
+nfs_server_daemon: nfs-server
+


### PR DESCRIPTION
Adds sles 15/16 and openSUSE support by creating OS-specific task files, uses the correct package name and service name for SUSE systems. rpcbind config works correctly on SLES. tested on SLE 15 SP7 and SLE16. 