### PR TITLE
Update link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Available variables are listed below, along with default values (see `defaults/m
 
     nfs_exports: []
 
-A list of exports which will be placed in the `/etc/exports` file. See Ubuntu's simple [Network File System (NFS)](https://ubuntu.com/server/docs/service-nfs) guide for more info and examples. (Simple example: `nfs_exports: [ "/home/public    *(rw,sync,no_root_squash)" ]`).
+A list of exports which will be placed in the `/etc/exports` file. See Ubuntu's simple [Network File System (NFS)]([https://help.ubuntu.com/community/SettingUpNFSHowTo) guide for more info and examples. (Simple example: `nfs_exports: [ "/home/public    *(rw,sync,no_root_squash)" ]`).
 
     nfs_rpcbind_state: started
     nfs_rpcbind_enabled: true


### PR DESCRIPTION
Change the ubuntu guide about setting up an NFS. I found one who is praticly the same (I thing). The old link wasn't working (ubuntu delete the article) :/